### PR TITLE
chore: add working GitHub profile cards and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ Handler, Home Visits, Foster, Adopter, Adoption/Event Coordinator.
 
 ![Top Languages](https://github-profile-summary-cards.vercel.app/api/cards/repos-per-language?username=pgollucci&theme=nord_dark)
 ![GitHub Stats](https://github-profile-summary-cards.vercel.app/api/cards/stats?username=pgollucci&theme=nord_dark)
+![Profile Details](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=pgollucci&theme=nord_dark)
+![GitHub Streak](https://streak-stats.demolab.com?user=pgollucci&theme=nord)
+![Activity Graph](https://github-readme-activity-graph.vercel.app/graph?username=pgollucci&theme=nord)
+![Profile Views](https://komarev.com/ghpvc/?username=pgollucci&color=5e81ac)
+![Followers](https://img.shields.io/github/followers/pgollucci?style=for-the-badge)
+![Stars](https://img.shields.io/github/stars/pgollucci?style=for-the-badge)


### PR DESCRIPTION
## Summary
- add additional working GitHub profile cards/badges in README
- include profile details, streak, activity graph, views, followers, and stars

## Validation
- local markdown lint with CI-equivalent config (MD013 line length 120)
